### PR TITLE
chore: downgrade chainlink-evm

### DIFF
--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
-	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250421201900-888b361327e8
+	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250418172423-6b24a042d134
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250418155716-b70a99cec060
 	github.com/smartcontractkit/libocr v0.0.0-20250328171017-609ec10a5510
 	github.com/stretchr/testify v1.10.0

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250421201900-888b361327e8
-	github.com/smartcontractkit/chainlink-evm v0.0.0-20250422151218-2211e07b4434
+	github.com/smartcontractkit/chainlink-evm v0.0.0-20250418155716-b70a99cec060
 	github.com/smartcontractkit/libocr v0.0.0-20250328171017-609ec10a5510
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -379,12 +379,10 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250421201900-888b361327e8 h1:eId0v+nd9DsDJHoHZ+P21/QUlDq8MrABFji6htEyu10=
-github.com/smartcontractkit/chainlink-common v0.7.1-0.20250421201900-888b361327e8/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250418172423-6b24a042d134 h1:4CdrrMDzdo9lf1oUi3rGKuprV11TmyUpVMM7fyPsqJA=
+github.com/smartcontractkit/chainlink-common v0.7.1-0.20250418172423-6b24a042d134/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250418155716-b70a99cec060 h1:5dnr4CLdbzGBXgWhWdzGzaEdJ3Ky70lY0oRCDsoDTu8=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250418155716-b70a99cec060/go.mod h1:fAS8SDyCxiCIRujq7v3D1ISGCrDyuXxd9zOEjQllJL8=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250422151218-2211e07b4434 h1:Es0gyhcQQE/gPukhO84ZZzFz4ENOVQrpSa+eaH7f5g4=
-github.com/smartcontractkit/chainlink-evm v0.0.0-20250422151218-2211e07b4434/go.mod h1:0E3ZSaoqYBdwL3lnShpQSn0xlnW5xYa21MaHJf1ysCg=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 h1:12ijqMM9tvYVEm+nR826WsrNi6zCKpwBhuApq127wHs=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7/go.mod h1:FX7/bVdoep147QQhsOPkYsPEXhGZjeYx6lBSaSXtZOA=
 github.com/smartcontractkit/libocr v0.0.0-20250328171017-609ec10a5510 h1:gm8Jli0sdkrZYnrWBngAkPSDzFDkdNCy1/Dj86kVtYk=

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -381,6 +381,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250421201900-888b361327e8 h1:eId0v+nd9DsDJHoHZ+P21/QUlDq8MrABFji6htEyu10=
 github.com/smartcontractkit/chainlink-common v0.7.1-0.20250421201900-888b361327e8/go.mod h1:vHs/mPpAztdKJtzRKLnmLinmpS78fBh9sAuyKqQrQ+I=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250418155716-b70a99cec060 h1:5dnr4CLdbzGBXgWhWdzGzaEdJ3Ky70lY0oRCDsoDTu8=
+github.com/smartcontractkit/chainlink-evm v0.0.0-20250418155716-b70a99cec060/go.mod h1:fAS8SDyCxiCIRujq7v3D1ISGCrDyuXxd9zOEjQllJL8=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250422151218-2211e07b4434 h1:Es0gyhcQQE/gPukhO84ZZzFz4ENOVQrpSa+eaH7f5g4=
 github.com/smartcontractkit/chainlink-evm v0.0.0-20250422151218-2211e07b4434/go.mod h1:0E3ZSaoqYBdwL3lnShpQSn0xlnW5xYa21MaHJf1ysCg=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 h1:12ijqMM9tvYVEm+nR826WsrNi6zCKpwBhuApq127wHs=

--- a/relayer/plugin/relayer.go
+++ b/relayer/plugin/relayer.go
@@ -262,7 +262,3 @@ func (t *TronRelayer) LatestHead(ctx context.Context) (types.Head, error) {
 func (t *TronRelayer) Replay(ctx context.Context, fromBlock string, args map[string]any) error {
 	return errors.New("TODO")
 }
-
-func (t *TronRelayer) NewEVMChain(ctx context.Context) (types.EVMChain, error) {
-	return nil, errors.New("TODO")
-}


### PR DESCRIPTION
Downgrades chainlink-evm to allow for chainlink-tron to be imported in core